### PR TITLE
Permit the HTTP client RequestConfig obj to be customized

### DIFF
--- a/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
+++ b/src/main/java/edu/uci/ics/crawler4j/crawler/CrawlConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.http.Header;
 import org.apache.http.client.config.CookieSpecs;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.message.BasicHeader;
 
 import edu.uci.ics.crawler4j.crawler.authentication.AuthInfo;
@@ -194,6 +195,11 @@ public class CrawlConfig {
      * Whether to honor "noindex" flag
      */
     private boolean respectNoIndex = true;
+
+    /**
+     * HTTP client RequestConfig
+     */
+    private RequestConfig requestConfig;
 
     /**
      * Validates the configs specified by this instance.
@@ -579,6 +585,24 @@ public class CrawlConfig {
 
     public void setRespectNoIndex(boolean respectNoIndex) {
         this.respectNoIndex = respectNoIndex;
+    }
+
+    public RequestConfig getRequestConfig() {
+        if (requestConfig == null) {
+            return RequestConfig.custom()
+            .setExpectContinueEnabled(false)
+            .setCookieSpec(getCookiePolicy())
+            .setRedirectsEnabled(false)
+            .setSocketTimeout(getSocketTimeout())
+            .setConnectTimeout(getConnectionTimeout())
+            .build();
+        }
+
+        return requestConfig;
+    }
+
+    public void overrideRequestConfig(RequestConfig config) {
+        this.requestConfig = config;
     }
 
     @Override

--- a/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
+++ b/src/main/java/edu/uci/ics/crawler4j/fetcher/PageFetcher.java
@@ -84,14 +84,7 @@ public class PageFetcher extends Configurable {
     public PageFetcher(CrawlConfig config) {
         super(config);
 
-        RequestConfig requestConfig = RequestConfig.custom()
-                                                   .setExpectContinueEnabled(false)
-                                                   .setCookieSpec(config.getCookiePolicy())
-                                                   .setRedirectsEnabled(false)
-                                                   .setSocketTimeout(config.getSocketTimeout())
-                                                   .setConnectTimeout(config.getConnectionTimeout())
-                                                   .build();
-
+        RequestConfig requestConfig = config.getRequestConfig();
         RegistryBuilder<ConnectionSocketFactory> connRegistryBuilder = RegistryBuilder.create();
         connRegistryBuilder.register("http", PlainConnectionSocketFactory.INSTANCE);
         if (config.isIncludeHttpsPages()) {


### PR DESCRIPTION
The RequestConfig object maintains a number of settings related
to the HTTP client so exposing it via the CrawlConfig makes a
number of settings configurable.